### PR TITLE
Compiler binary usage

### DIFF
--- a/compil/src/main.ml
+++ b/compil/src/main.ml
@@ -1,6 +1,8 @@
 let _ =
   if Array.length Sys.argv != 2 then
     print_string "Usage: ./main.native filename.tricot\n"
+  else if not (Sys.file_exists Sys.argv.(1)) then
+    print_string "File does not exist.\n"
   else
     let input = open_in Sys.argv.(1) in
     let buf = Lexing.from_channel input in


### PR DESCRIPTION
I fixed a bit the main.ml file to show nice error messages instead of crashing because of basic issues of the binary usage.
